### PR TITLE
Fix NPE in BaseResourceTypeResourceImpl

### DIFF
--- a/scim-server/scim-server-common/src/main/java/edu/psu/swe/scim/server/rest/BaseResourceTypeResourceImpl.java
+++ b/scim-server/scim-server-common/src/main/java/edu/psu/swe/scim/server/rest/BaseResourceTypeResourceImpl.java
@@ -201,8 +201,8 @@ public abstract class BaseResourceTypeResourceImpl<T extends ScimResource> imple
                                                 .map(wrapper -> wrapper.getAttributeReferences())
                                                 .orElse(Collections.emptySet()));
 
-    searchRequest.setFilter(filter.getFilter());
-
+    searchRequest.setFilter((filter != null) ? filter.getFilter() : null);
+    
     searchRequest.setSortBy(sortBy);
     searchRequest.setSortOrder(sortOrder);
     searchRequest.setStartIndex(startIndex);


### PR DESCRIPTION
Add a null check to the FilterWrapper object in the query method to avoid NPE when building the SearchRequest object. This was preventing SCIM GET without a filter from executing properly.