### PR TITLE
Change REPLACE to ADD when the node value is a list

### DIFF
--- a/scim-server/scim-server-common/src/main/java/edu/psu/swe/scim/server/provider/UpdateRequest.java
+++ b/scim-server/scim-server-common/src/main/java/edu/psu/swe/scim/server/provider/UpdateRequest.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -42,7 +41,6 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import com.flipkart.zjsonpatch.JsonDiff;
 
-import edu.psu.swe.scim.server.rest.ObjectMapperContextResolver;
 import edu.psu.swe.scim.server.schema.Registry;
 import edu.psu.swe.scim.spec.protocol.attribute.AttributeReference;
 import edu.psu.swe.scim.spec.protocol.data.PatchOperation;
@@ -323,6 +321,10 @@ public class UpdateRequest<T extends ScimResource> {
     }
     
     ParseData parseData = new ParseData(diffPath);
+    
+    if (patchOpType == Type.REPLACE && valueNode instanceof ArrayNode) {
+      patchOpType = Type.ADD;
+    }
 
     if (parseData.pathParts.isEmpty()) {
       return handleExtensions(valueNode, patchOpType, parseData);
@@ -411,7 +413,6 @@ public class UpdateRequest<T extends ScimResource> {
     
     if (patchOpType == Type.REPLACE && parseData.originalObject == null) {
       patchOpType = Type.ADD;
-      //valueNode = null;
     }
 
     PatchOperation operation = new PatchOperation();
@@ -432,17 +433,6 @@ public class UpdateRequest<T extends ScimResource> {
     }
   }
   
-  private Class<?> getClassOfResource(ParseData parseData) {
-    if (parseData.originalObject != null) {
-      return parseData.originalObject.getClass();
-    }
-    if (parseData.resourceObject != null) {
-      return parseData.resourceObject.getClass();
-    }
-    
-    return null;
-  }
-
   private Object determineValue(PatchOperation.Type patchOpType, JsonNode valueNode, ParseData parseData) throws JsonProcessingException {
     if (patchOpType == PatchOperation.Type.REMOVE) {
       return null;

--- a/scim-server/scim-server-common/src/test/java/edu/psu/swe/scim/server/provider/UpdateRequestTest.java
+++ b/scim-server/scim-server-common/src/test/java/edu/psu/swe/scim/server/provider/UpdateRequestTest.java
@@ -62,7 +62,6 @@ public class UpdateRequestTest {
   private static final String A = "A";
   private static final String B = "B";
   private static final String C = "C";
-  private static final String D = "D";
 
   @Rule
   public MockitoRule mockito = MockitoJUnit.rule();
@@ -136,7 +135,7 @@ public class UpdateRequestTest {
 
     PatchOperation actual = assertSingleResult(result);
 
-    checkAssertions(actual, Type.ADD, "nickName", "Jon");
+    checkAssertions(actual, Type.REPLACE, "nickName", "Jon");
   }
   
   @Test
@@ -170,7 +169,7 @@ public class UpdateRequestTest {
 
     PatchOperation actual = assertSingleResult(result);
 
-    checkAssertions(actual, Type.ADD, "name.honorificPrefix", "Dr.");
+    checkAssertions(actual, Type.REPLACE, "name.honorificPrefix", "Dr.");
   }
 
   @Test
@@ -503,7 +502,7 @@ public class UpdateRequestTest {
     updateRequest.initWithResource("1234", user1, user2);
     List<PatchOperation> operations = updateRequest.getPatchOperations();
     Assert.assertNotNull(operations);
-    Assert.assertEquals(2, operations.size());
+    Assert.assertEquals(3, operations.size());
     PatchOperation operation = operations.get(0);
     Assert.assertNotNull(operation.getValue());
     Assert.assertEquals(Type.ADD, operation.getOperation());
@@ -720,14 +719,18 @@ public class UpdateRequestTest {
     //  3b Path
     //  3c Value
     
+    List<ExpectedPatchOperation> multipleOps = new ArrayList<ExpectedPatchOperation>();
+    multipleOps.add(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "A"));
+    multipleOps.add(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "B"));
+    multipleOps.add(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "C"));
     params.add(new Object[] {Stream.of(A).collect(Collectors.toList()), new ArrayList<String>(), Stream.of(new ExpectedPatchOperation("REMOVE", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", null)).collect(Collectors.toList())});
     params.add(new Object[] {Stream.of(A).collect(Collectors.toList()), null, Stream.of(new ExpectedPatchOperation("REMOVE", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", null)).collect(Collectors.toList())});
-    params.add(new Object[] {null, Stream.of(A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "[A]")).collect(Collectors.toList())});
-    params.add(new Object[] {null, Stream.of(C,B,A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "[A, B, C]")).collect(Collectors.toList())});
+    params.add(new Object[] {null, Stream.of(A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "A")).collect(Collectors.toList())});
+    params.add(new Object[] {null, Stream.of(C,B,A).collect(Collectors.toList()), multipleOps});
     params.add(new Object[] {Stream.of(A,B,C).collect(Collectors.toList()), new ArrayList<String>(), Stream.of(new ExpectedPatchOperation("REMOVE", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", null)).collect(Collectors.toList())});
     params.add(new Object[] {Stream.of(C,B,A).collect(Collectors.toList()), new ArrayList<String>(), Stream.of(new ExpectedPatchOperation("REMOVE", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", null)).collect(Collectors.toList())});
-    params.add(new Object[] {new ArrayList<String>(), Stream.of(A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "[A]")).collect(Collectors.toList())});
-    params.add(new Object[] {new ArrayList<String>(), Stream.of(C,B,A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "[A, B, C]")).collect(Collectors.toList())});
+    params.add(new Object[] {new ArrayList<String>(), Stream.of(A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "A")).collect(Collectors.toList())});
+    params.add(new Object[] {new ArrayList<String>(), Stream.of(C,B,A).collect(Collectors.toList()), multipleOps});
     
     
     params.add(new Object[] {Stream.of(A, B).collect(Collectors.toList()), Stream.of(B).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("REMOVE", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list[value EQ \"A\"]", null)).collect(Collectors.toList())});

--- a/scim-server/scim-server-common/src/test/java/edu/psu/swe/scim/server/provider/UpdateRequestTest.java
+++ b/scim-server/scim-server-common/src/test/java/edu/psu/swe/scim/server/provider/UpdateRequestTest.java
@@ -726,8 +726,8 @@ public class UpdateRequestTest {
     params.add(new Object[] {null, Stream.of(C,B,A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "[A, B, C]")).collect(Collectors.toList())});
     params.add(new Object[] {Stream.of(A,B,C).collect(Collectors.toList()), new ArrayList<String>(), Stream.of(new ExpectedPatchOperation("REMOVE", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", null)).collect(Collectors.toList())});
     params.add(new Object[] {Stream.of(C,B,A).collect(Collectors.toList()), new ArrayList<String>(), Stream.of(new ExpectedPatchOperation("REMOVE", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", null)).collect(Collectors.toList())});
-    params.add(new Object[] {new ArrayList<String>(), Stream.of(A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("REPLACE", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "[A]")).collect(Collectors.toList())});
-    params.add(new Object[] {new ArrayList<String>(), Stream.of(C,B,A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("REPLACE", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "[A, B, C]")).collect(Collectors.toList())});
+    params.add(new Object[] {new ArrayList<String>(), Stream.of(A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "[A]")).collect(Collectors.toList())});
+    params.add(new Object[] {new ArrayList<String>(), Stream.of(C,B,A).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("ADD", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "[A, B, C]")).collect(Collectors.toList())});
     
     
     params.add(new Object[] {Stream.of(A, B).collect(Collectors.toList()), Stream.of(B).collect(Collectors.toList()), Stream.of(new ExpectedPatchOperation("REMOVE", "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list[value EQ \"A\"]", null)).collect(Collectors.toList())});

--- a/scim-server/scim-server-common/src/test/java/edu/psu/swe/scim/server/provider/UpdateRequestTest.java
+++ b/scim-server/scim-server-common/src/test/java/edu/psu/swe/scim/server/provider/UpdateRequestTest.java
@@ -179,8 +179,36 @@ public class UpdateRequestTest {
 
     checkAssertions(actual, Type.ADD, "phoneNumbers", mobilePhone);
   }
-
   
+  /**
+   * This unit test is to replicate the issue where a replace is sent back
+   * from the differencing engine for a collection that is currently empty
+   * but is having an object added to it. This should produce an ADD with an
+   * ArrayList of objects to add.
+   */
+  @Test
+  public void testAddObjectsToEmptyCollection() throws Exception {
+    UpdateRequest<ScimUser> updateRequest = new UpdateRequest<>(registry);
+
+    ScimUser user1 = createUser1();
+    user1.setPhoneNumbers(new ArrayList<PhoneNumber>());
+    ScimUser user2 = copy(user1);
+    
+    PhoneNumber mobilePhone = new GlobalPhoneNumberBuilder().globalNumber("+1(814)867-5306").build();
+    mobilePhone.setType("mobile");
+    mobilePhone.setPrimary(true);
+    user2.getPhoneNumbers().add(mobilePhone);
+    
+    updateRequest.initWithResource("1234", user1, user2);
+    List<PatchOperation> operations = updateRequest.getPatchOperations();
+    Assert.assertNotNull(operations);
+    Assert.assertEquals(1, operations.size());
+    PatchOperation operation = operations.get(0);
+    Assert.assertNotNull(operation.getValue());
+    Assert.assertEquals(Type.ADD, operation.getOperation());
+    Assert.assertEquals(ArrayList.class, operation.getValue().getClass());
+  }
+
   @Test
   public void testReplaceSingleAttribute() throws Exception {
     UpdateRequest<ScimUser> updateRequest = new UpdateRequest<>(registry);


### PR DESCRIPTION
ISSUE #38: Modified convertToPatchOperation to change the patch
operation type from REPLACE to ADD when the node value is an array list.