### PR TITLE
Feature/client handle invalid error response

### DIFF
--- a/scim-client/src/main/java/edu/psu/swe/scim/client/rest/BaseScimClient.java
+++ b/scim-client/src/main/java/edu/psu/swe/scim/client/rest/BaseScimClient.java
@@ -3,6 +3,7 @@ package edu.psu.swe.scim.client.rest;
 import java.util.Optional;
 import java.util.function.Function;
 
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
@@ -11,6 +12,7 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import edu.psu.swe.commons.jaxrs.ErrorMessage;
 import edu.psu.swe.commons.jaxrs.RestCall;
 import edu.psu.swe.commons.jaxrs.exceptions.RestClientException;
 import edu.psu.swe.commons.jaxrs.utilities.RestClientUtil;
@@ -166,6 +168,9 @@ public abstract class BaseScimClient<T extends ScimResource> implements AutoClos
 
         throw new ScimException(errorResponse, status);
       }
+    } catch (ProcessingException e) {
+      ErrorResponse er = new ErrorResponse(Status.INTERNAL_SERVER_ERROR, e.getMessage());
+      throw new ScimException(er, Status.INTERNAL_SERVER_ERROR);
     } finally {
       RestClientUtil.close(response);
     }

--- a/scim-client/src/main/java/edu/psu/swe/scim/client/rest/BaseScimClient.java
+++ b/scim-client/src/main/java/edu/psu/swe/scim/client/rest/BaseScimClient.java
@@ -12,7 +12,6 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import edu.psu.swe.commons.jaxrs.ErrorMessage;
 import edu.psu.swe.commons.jaxrs.RestCall;
 import edu.psu.swe.commons.jaxrs.exceptions.RestClientException;
 import edu.psu.swe.commons.jaxrs.utilities.RestClientUtil;

--- a/scim-server/scim-server-common/src/main/java/edu/psu/swe/scim/server/rest/BaseResourceTypeResourceImpl.java
+++ b/scim-server/scim-server-common/src/main/java/edu/psu/swe/scim/server/rest/BaseResourceTypeResourceImpl.java
@@ -459,6 +459,8 @@ public abstract class BaseResourceTypeResourceImpl<T extends ScimResource> imple
         updated = provider.update(updateRequest);
       } catch (UnableToUpdateResourceException e1) {
         return createGenericExceptionResponse(e1, e1.getStatus());
+      } catch (Exception e1) {
+        return createGenericExceptionResponse(e1, Status.INTERNAL_SERVER_ERROR);
       }
 
       // Process Attributes
@@ -556,6 +558,8 @@ public abstract class BaseResourceTypeResourceImpl<T extends ScimResource> imple
         updated = provider.update(updateRequest);
       } catch (UnableToUpdateResourceException e1) {
         return createGenericExceptionResponse(e1, e1.getStatus());
+      } catch (Exception e1) {
+        return createGenericExceptionResponse(e1, Status.INTERNAL_SERVER_ERROR);
       }
 
       // Process Attributes


### PR DESCRIPTION
When making a SCIM call into a system, sometimes an error response that is not a ErrorResponse is returned (usually an Apache stacktrace). When the Client code attempts to parse the payload of the response to Throws a javax.ws.rs.ProcessingException. Since this is a RuntimeException, the calling system cannot handle the failed request without catching Runtime Exception. This update will throw a Checked exception instead.