### PR TITLE
Add NOT_IMPLEMENTED to patch operation

### DIFF
--- a/scim-server/scim-server-common/src/main/java/edu/psu/swe/scim/server/provider/UpdateRequest.java
+++ b/scim-server/scim-server-common/src/main/java/edu/psu/swe/scim/server/provider/UpdateRequest.java
@@ -175,8 +175,7 @@ public class UpdateRequest<T extends ScimResource> {
   }
 
   private T applyPatchOperations() {
-    // TODO Auto-generated method stub
-    return resource;
+    throw new java.lang.UnsupportedOperationException("PATCH operations are not implemented at this time.");
   }
   
   /**

--- a/scim-server/scim-server-common/src/main/java/edu/psu/swe/scim/server/rest/BaseResourceTypeResourceImpl.java
+++ b/scim-server/scim-server-common/src/main/java/edu/psu/swe/scim/server/rest/BaseResourceTypeResourceImpl.java
@@ -566,6 +566,8 @@ public abstract class BaseResourceTypeResourceImpl<T extends ScimResource> imple
         updated = provider.update(updateRequest);
       } catch (UnableToUpdateResourceException e1) {
         return createGenericExceptionResponse(e1, e1.getStatus());
+      } catch (UnsupportedOperationException e2) {
+        return createGenericExceptionResponse(e2, Status.NOT_IMPLEMENTED);
       } catch (Exception e1) {
         log.error("Uncaught provider exception", e1);
 

--- a/scim-server/scim-server-common/src/test/java/edu/psu/swe/scim/server/provider/UpdateRequestTest.java
+++ b/scim-server/scim-server-common/src/test/java/edu/psu/swe/scim/server/provider/UpdateRequestTest.java
@@ -111,15 +111,12 @@ public class UpdateRequestTest {
               .isNotNull();
   }
 
-  @Test
-  @Ignore
+  @Test(expected=UnsupportedOperationException.class)
   public void testPatchToUpdate() throws Exception {
     UpdateRequest<ScimUser> updateRequest = new UpdateRequest<>(registry);
     updateRequest.initWithPatch("1234", createUser1(), createUser1PatchOps());
-    ScimUser result = updateRequest.getResource();
-    log.info("testPatchToUpdate: " + result);
-    Assertions.assertThat(result)
-              .isNotNull();
+        
+    updateRequest.getResource();
   }
 
   @Test


### PR DESCRIPTION
Issue #49

- Throw UnsupportedOperationException from
UpdateRequest.applyPatchOperations until feature can be implmented
- Catch exception in BaseResourceTypeResourceImpl.patch() and return a
status of NOT_IMPLEMENTED