### PR TITLE
Added default false value for PhoneNumber's primary flag. 

### DIFF
--- a/scim-spec/scim-spec-schema/src/main/java/edu/psu/swe/scim/spec/resources/PhoneNumber.java
+++ b/scim-spec/scim-spec-schema/src/main/java/edu/psu/swe/scim/spec/resources/PhoneNumber.java
@@ -71,7 +71,7 @@ public class PhoneNumber extends KeyedResource implements Serializable, TypedAtt
   @ScimAttribute(description = "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g. the preferred phone number or primary phone number. The primary attribute value 'true' MUST appear no more than once.")
   @Getter
   @Setter
-  Boolean primary;
+  Boolean primary = false;
 
   @Setter(AccessLevel.NONE)
   @Getter


### PR DESCRIPTION
When the primary flag was not specified, serializing a ScimUser would throw a NPE. This fixes the NPE. Also, the primary flag in EmailAddress and Address have a false default value. This makes PhoneNumber consistent with them.